### PR TITLE
fix: allow read only Flatpak access to `/opt` to find icons stored in there from native applications

### DIFF
--- a/packaging/io.github.crocodile.cosmic-ext-applet-workspace-icons/io.github.crocodile.cosmic-ext-applet-workspace-icons.json
+++ b/packaging/io.github.crocodile.cosmic-ext-applet-workspace-icons/io.github.crocodile.cosmic-ext-applet-workspace-icons.json
@@ -19,6 +19,7 @@
     "--talk-name=com.system76.CosmicSettingsDaemon.Config.*",
     "--filesystem=xdg-config/cosmic:rw",
     "--filesystem=host-os:ro",
+    "--filesystem=/opt:ro",
     "--filesystem=/var/lib/snapd/desktop:ro",
     "--filesystem=/var/lib/snapd/snap:ro",
     "--filesystem=/var/lib/flatpak/exports/share/applications:ro",


### PR DESCRIPTION
Some applications (e.g. Zen browser) ship their icons in `/opt` with symlinks pointing to that.
Without access to `/opt` the applet sees the symlink but the icon itself lives outside its sandbox.
Thus access is not allowed and the icon is not shown.

Adding `/opt` as a read only filesystem permission to the Flatpak fixes this.

Fixes #10 