### PR TITLE
i18n(cs): Add Czech translation

### DIFF
--- a/i18n/cs/cosmic_ext_applet_workspace_icons.ftl
+++ b/i18n/cs/cosmic_ext_applet_workspace_icons.ftl
@@ -1,1 +1,3 @@
-cosmic-applet-workspaces = Pracovní plochy COSMIC
+cosmic-ext-applet-workspace-icons = Ikony pracovních ploch
+dim-minimized-window-icons = Ztlumit ikony minimalizovaných oken
+highlight-maximized-window-icons = Zvýraznit ikony maximalizovaných oken

--- a/resources/io.github.crocodile.cosmic-ext-applet-workspace-icons.desktop
+++ b/resources/io.github.crocodile.cosmic-ext-applet-workspace-icons.desktop
@@ -1,11 +1,14 @@
 [Desktop Entry]
 Name=Workspace Icons
+Name[cs]=Ikony pracovních ploch
 Comment=Show application icons on COSMIC workspaces
+Comment[cs]=Zobrazuje ikony aplikací na pracovních plochách COSMIC
 Type=Application
 Exec=cosmic-ext-applet-workspace-icons
 Terminal=false
 Categories=COSMIC;
 Keywords=COSMIC;Applet;Workspace;Workspaces;Icons;
+Keywords[cs]=COSMIC;Applet;Pracovní;Plocha;Plochy;Ikony;
 Icon=io.github.crocodile.cosmic-ext-applet-workspace-icons
 StartupNotify=true
 NoDisplay=true

--- a/resources/io.github.crocodile.cosmic-ext-applet-workspace-icons.metainfo.xml
+++ b/resources/io.github.crocodile.cosmic-ext-applet-workspace-icons.metainfo.xml
@@ -8,19 +8,25 @@
     <name>crocodile</name>
   </developer>
   <name>Workspace Icons</name>
+  <name xml:lang="cs">Ikony pracovních ploch</name>
   <summary>Show app icons beside COSMIC workspaces</summary>
+  <summary xml:lang="cs">Zobrazuje ikony aplikací vedle pracovních ploch COSMIC</summary>
   <description>
     <p>Workspace Icons adds application icons to the COSMIC panel's numbered workspaces, so you can see where your windows are at a glance.</p>
+    <p xml:lang="cs">Applet „Ikony pracovních ploch“ přidává ikony aplikací k číslovaným pracovním plochám panelu COSMIC, takže na první pohled uvidíte, kde se nacházejí vaše okna.</p>
     <p>It keeps the normal workspace switching, scrolling, and overview behavior while adding compact indicators for open, minimized, and maximized windows.</p>
+    <p xml:lang="cs">Zachovává běžné přepínání pracovních ploch, rolování i chování přehledu a zároveň přidává kompaktní indikátory otevřených, minimalizovaných a maximalizovaných oken.</p>
   </description>
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/crocodile/cosmic-ext-applet-workspace-icons/main/resources/screenshots/workspace-icons-panel-1.png</image>
       <caption>Application icons shown beside workspace numbers in the COSMIC panel.</caption>
+      <caption xml:lang="cs">Ikony aplikací zobrazené vedle čísel pracovních ploch v panelu COSMIC.</caption>
     </screenshot>
     <screenshot>
       <image>https://raw.githubusercontent.com/crocodile/cosmic-ext-applet-workspace-icons/main/resources/screenshots/workspace-icons-panel-2.png</image>
       <caption>Settings for dimming minimized windows and highlighting maximized windows.</caption>
+      <caption xml:lang="cs">Nastavení pro ztlumení minimalizovaných oken a zvýraznění maximalizovaných oken.</caption>
     </screenshot>
   </screenshots>
   <launchable type="desktop-id">io.github.crocodile.cosmic-ext-applet-workspace-icons.desktop</launchable>
@@ -49,6 +55,9 @@
     <keyword>Workspaces</keyword>
     <keyword>Icons</keyword>
     <keyword>Panel</keyword>
+    <keyword xml:lang="cs">Pracovní plocha</keyword>
+    <keyword xml:lang="cs">Pracovní plochy</keyword>
+    <keyword xml:lang="cs">Ikony</keyword>
   </keywords>
   <releases>
     <release type="stable" version="1.0.2" date="2026-07-14">


### PR DESCRIPTION
Translates `.ftl`, `.metainfo.xml` and `.desktop` files to czech. For the `.ftl` file, I copied contents of the english `.ftl` file, as it's the only one containing the strings I actually see in the applet.