### PR TITLE
Fix frosted glass blur on the settings popup

### DIFF
--- a/src/components/app.rs
+++ b/src/components/app.rs
@@ -29,7 +29,6 @@ use cosmic::{
         Event::Mouse,
         Length, Limits, Padding, Subscription, event,
         mouse::{self, ScrollDelta},
-        platform_specific::shell::wayland::commands::popup::{destroy_popup, get_popup},
         widget::{Image, Svg, button, column, row, space, stack},
         window,
     },
@@ -1515,19 +1514,23 @@ impl cosmic::Application for IcedWorkspacesApplet {
             }
             Message::TogglePopup => {
                 return if let Some(popup) = self.popup.take() {
-                    destroy_popup(popup)
+                    surface::surface_task(surface::action::destroy_popup(popup))
                 } else {
-                    let popup = window::Id::unique();
-                    self.popup.replace(popup);
-                    let popup_settings = self.core.applet.get_popup_settings(
-                        self.core.main_window_id().unwrap(),
-                        popup,
-                        Some((1, 1)),
+                    surface::surface_task(surface::action::app_popup(
+                        |_| Default::default(),
+                        |app: &mut Self| {
+                            let popup = window::Id::unique();
+                            app.popup.replace(popup);
+                            app.core.applet.get_popup_settings(
+                                app.core.main_window_id().unwrap(),
+                                popup,
+                                Some((1, 1)),
+                                None,
+                                None,
+                            )
+                        },
                         None,
-                        None,
-                    );
-
-                    get_popup(popup_settings)
+                    ))
                 };
             }
             Message::PopupClosed(id) => {


### PR DESCRIPTION
## Summary

- create and destroy the settings popup through libcosmic's tracked surface actions
- allow libcosmic to identify the surface as an applet popup and apply compositor blur
- retain the existing COSMIC-themed translucent popup container

## Root cause

The applet called the low-level Wayland popup command directly. That bypassed libcosmic's popup surface tracking, so the transparent themed background was rendered without the frosted-glass blur region and content behind the popup remained sharp.

## Validation

- `cargo check`
- `cargo test` (27 passed)
- `git diff --check`

Closes #20
