### PR TITLE
Pin Flatpak build to latest main release

### DIFF
--- a/packaging/io.github.crocodile.cosmic-ext-applet-workspace-icons/io.github.crocodile.cosmic-ext-applet-workspace-icons.json
+++ b/packaging/io.github.crocodile.cosmic-ext-applet-workspace-icons/io.github.crocodile.cosmic-ext-applet-workspace-icons.json
@@ -56,7 +56,7 @@
         {
           "type": "git",
           "url": "https://github.com/crocodile/cosmic-ext-applet-workspace-icons.git",
-          "commit": "76d316beb82ce0cb5bb0039a2a79796cc57d22b3"
+          "commit": "72d5adc57881bef38baacd0cd359e1d184ba213c"
         },
         {
           "type": "file",


### PR DESCRIPTION
Updates the Flatpak source pin to `72d5adc57881bef38baacd0cd359e1d184ba213c`, the latest release commit on `main` including the Czech translation.

The manifest remains valid JSON and the change is limited to the immutable source commit.